### PR TITLE
Check for updates only, modified Twitter_Account <-> Tracker association

### DIFF
--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -25,15 +25,15 @@ module.exports = {
     var influencers = req.body.influencers;
     console.log('sent influencers:', influencers)
     console.log('user id:', req.session.user.id)
-    Twitter_Account.findOne({user: req.session.user.id}).populate('influencers').exec(function(err, twitterAcc){
+    Twitter_Account.findOne({user: req.session.user.id}).populate('trackers').exec(function(err, twitterAcc){
       console.log('found twitter account:', twitterAcc)
       async.each(influencers, function(influencer, callback) {
-        Tracker.findOrCreate({name: influencer.screen_name}, {name: influencer.screen_name, type: 'influencer', twitter_account: twitterAcc.id}).exec(function(err, addedInfluencer){
+        Tracker.findOrCreate({name: influencer.screen_name}, {name: influencer.screen_name, type: 'influencer', twitter_accounts: twitterAcc.id}).exec(function(err, addedInfluencer){
           console.log('added influencer:', addedInfluencer)
-          if (!Array.isArray(twitterAcc)) {
-            twitterAcc.influencers = [];
+          if (!Array.isArray(twitterAcc.trackers)) {
+            twitterAcc.trackers = [];
           }
-          twitterAcc.influencers.push(addedInfluencer);
+          twitterAcc.trackers.push(addedInfluencer);
           twitterAcc.save();
           callback()
         })
@@ -42,7 +42,7 @@ module.exports = {
           console.log('there has been an error updating influencers:',err)
           res.send({error: err})
         }else{
-          res.send({influencers: twitterAcc.influencers})
+          res.send({influencers: twitterAcc.trackers})
         }
       })
     })

--- a/api/helpers/utilities.js
+++ b/api/helpers/utilities.js
@@ -181,6 +181,50 @@ module.exports = {
         callback(error, response);
       }
     });
+  },
+
+  getPreviousDate: function() {
+    var d = new Date(Date.now());
+    var dStr = '';
+    if(d.getDate() === 1) {
+      if(d.getMonth() === 0) {
+        dStr = d.getFullYear()-1 + '-12-31';
+      } else {
+        dStr = d.getFullYear() + '-' + (d.getMonth() + 1);
+        switch(d.getMonth() + 1) {
+          case 1:
+          case 3:
+          case 5:
+          case 7:
+          case 8:
+          case 10:
+          case 12:
+            dStr += '-31';
+            break;
+          case 4:
+          case 6:
+          case 9:
+          case 11:
+            dStr += '-30';
+            break;
+          case 2:
+            var y = d.getFullYear();
+            if((y % 4 === 0 && y % 100 !== 0) || y % 400 === 0) {
+              dStr += '-29';
+            } else {
+              dStr += '-28'
+            }
+            break;
+          default:
+            dStr += '-30';
+            break;
+        }
+      }
+    } else {
+        dStr = d.getFullYear() + '-' + (d.getMonth() + 1) + '-' + (d.getDate() - 1)
+    }
+
+    return dStr;
   }
 
 }

--- a/api/models/Tracker.js
+++ b/api/models/Tracker.js
@@ -21,8 +21,9 @@ module.exports = {
     //////////////////
     // Associations //
     //////////////////
-    twitter_account: {
-      model: 'Twitter_Account'
+    twitter_accounts: {
+      collection: 'Twitter_Account',
+      via: 'trackers'
     }
   }
 };

--- a/api/models/Twitter_Account.js
+++ b/api/models/Twitter_Account.js
@@ -55,15 +55,9 @@ module.exports = {
     user: {
       model: 'User'
     },
-    influencers: {
+    trackers: {
       collection: 'Tracker',
-      via: 'twitter_account'
-    },
-    hashtags: {
-      collection: 'Tracker'
-    },
-    mentions: {
-      collection: 'Tracker'
+      via: 'twitter_accounts'
     }
   }
 };

--- a/assets/js/controllers/HomeCtrl.js
+++ b/assets/js/controllers/HomeCtrl.js
@@ -112,7 +112,7 @@ TwitterMafia.controller('HomeCtrl', ['$scope', '$rootScope', '$http', '$mdToast'
 
   if($rootScope.currentUser){
     // $scope.updateUser();
-    $scope.retrieveUser();
+    // $scope.retrieveUser();
   }
 
   L.mapbox.accessToken = 'pk.eyJ1IjoiYmVubmV0dHNsaW4iLCJhIjoiYzU0V200YyJ9._G57JU3841MTuFULQD9pVg';


### PR DESCRIPTION
Removed the separate associations for the different types of trackers, all go through the many-to-many 'trackers' association now. Added logic to check only tweets after the latest tweets stored, including fall-back logic if no data is stored.
